### PR TITLE
Refactor css

### DIFF
--- a/App/src/main/java/com/gluonhq/chat/views/MessageCell.java
+++ b/App/src/main/java/com/gluonhq/chat/views/MessageCell.java
@@ -50,7 +50,7 @@ class MessageCell extends CharmListCell<ChatMessage> {
     private static final Insets meInsets = new Insets(10, 0, 10, 0);
     private static final Insets notMeInsets = new Insets(10, 0, 10, 0);
     private static final Image clockImage = new Image( "/clock.png");
-    private static final PseudoClass SIDE_RIGHT = PseudoClass.getPseudoClass("right");
+    private static final PseudoClass SENT_PSEUDO_CLASS = PseudoClass.getPseudoClass("sent");
     private static final PseudoClass UNREAD = PseudoClass.getPseudoClass("unread");
     private static final PseudoClass READ = PseudoClass.getPseudoClass("read");
     private static final Image loading = new Image(MessageCell.class.getResourceAsStream("/InternetSlowdown_Day.gif"), 150, 150, true, true);
@@ -62,7 +62,6 @@ class MessageCell extends CharmListCell<ChatMessage> {
     private final BorderPane messageBubble;
     private final Label date  = new Label();
     private final Label status  = new Label();
-//    private final Label icon = new Label("ICON");
     private final Label unread;
     private final BorderPane pane;
     private final StackPane stackPane;
@@ -79,12 +78,8 @@ class MessageCell extends CharmListCell<ChatMessage> {
 
         getStyleClass().addAll("chat-list-cell");
 
-//        icon.getStyleClass().add("user-icon");
-//        BorderPane.setAlignment(icon, Pos.TOP_CENTER);
-
         setWrapText(true);
         this.message = new TextFlow();
-//        message.getStyleClass().add("chat-message-text");
 
         dateAndStatus = new HBox(10, date, status);
         dateAndStatus.setMaxWidth(Region.USE_PREF_SIZE);
@@ -92,11 +87,9 @@ class MessageCell extends CharmListCell<ChatMessage> {
         messageBubble = new BorderPane(message);
         messageBubble.setBottom(dateAndStatus);
         messageBubble.setMaxWidth(Region.USE_PREF_SIZE);
-//        messageBubble.getStyleClass().add("chat-message-bubble");
-        messageBubble.getStyleClass().setAll("chat-message-text");
+        messageBubble.getStyleClass().setAll("chat-message-bubble");
 
         pane = new BorderPane(messageBubble);
-//        pane.setBottom(dateAndStatus);
         pane.getStyleClass().add("chat-message");
         pane.prefWidthProperty().bind(widthProperty());
 
@@ -140,16 +133,11 @@ class MessageCell extends CharmListCell<ChatMessage> {
                 status.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
             }
 
-//            icon.setText(isMe ? "ME" : Service.getInitials(item.getUser().displayName()));
-
             if (isMe) {
-
-                messageBubble.getStyleClass().setAll("chat-message-text", "chat-message-sent");
-                messageBubble.pseudoClassStateChanged(SIDE_RIGHT, true);
+                messageBubble.pseudoClassStateChanged(SENT_PSEUDO_CLASS, true);
                 messageBubble.setLeft(null);
                 messageBubble.setRight(msgHandle);
                 pane.setLeft(null);
-//                pane.setRight(icon);
                 BorderPane.setAlignment(message, Pos.TOP_RIGHT);
                 BorderPane.setAlignment(messageBubble, Pos.TOP_RIGHT);
                 BorderPane.setAlignment(dateAndStatus, Pos.BOTTOM_RIGHT);
@@ -161,14 +149,12 @@ class MessageCell extends CharmListCell<ChatMessage> {
                     item.receiptProperty()));
 
             } else {
-                messageBubble.getStyleClass().setAll("chat-message-text", "chat-message-received");
-                messageBubble.pseudoClassStateChanged(SIDE_RIGHT, false);
+                messageBubble.pseudoClassStateChanged(SENT_PSEUDO_CLASS, false);
                 messageBubble.setRight(null);
                 messageBubble.setLeft(msgHandle);
                 //status.setText(resources.getString("label.status.check.unknown")); // check mark if read
                 status.setText(""); // status is only needed for sent messages
                 pane.setRight(null);
-//                pane.setLeft(icon);
                 BorderPane.setAlignment(message, Pos.TOP_LEFT);
                 BorderPane.setAlignment(messageBubble, Pos.TOP_LEFT);
                 BorderPane.setAlignment(dateAndStatus, Pos.BOTTOM_LEFT);

--- a/App/src/main/resources/com/gluonhq/chat/views/channel.css
+++ b/App/src/main/resources/com/gluonhq/chat/views/channel.css
@@ -6,12 +6,12 @@
 }
 
 .search-box > .icon > .icon-text {
-    -fx-text-fill: -chat-text-fill;
+    -fx-text-fill: -chat-text-sent-fill-500;
 }
 
 .search-box > .charm-text-field > .text-field {
-    -fx-text-fill: -chat-text-fill;
-    -fx-prompt-text-fill: derive(-fx-text-fill, 10%);
+    -fx-text-fill: -chat-text-sent-fill-500;
+    -fx-prompt-text-fill: derive(-chat-text-sent-fill-500, 10%);
 }
 
 .channel-list,
@@ -26,29 +26,26 @@
 }
 
 .channel-list .list-cell.header-cell > .header-box {
-    -fx-background-color: -chat-background-light;
+    -fx-background-color: -chat-background-200;
     -fx-padding: 10;
     -fx-alignment: center-left;
 }
 
 .channel-list .list-cell.header-cell > .header-box > .label {
     -fx-font-weight: bold;
-    -fx-text-fill: -chat-text-fill;
+    -fx-text-fill: -chat-text-sent-fill-500;
     -fx-font-size: 1.2em;
 }
 
 .channel-list .list-cell .primary-text {
-    -fx-text-fill: -chat-text-fill;
+    -fx-text-fill: -chat-text-sent-fill-500;
 }
 
 .channel-list .channel-cell:hover {
-    -fx-background-color: -chat-background;
+    -fx-background-color: -chat-background-500;
 }
 
-.channel-list .channel-cell:selected {
-    -fx-background-color: -chat-accent-selected;
-}
-
+.channel-list .channel-cell:selected,
 .channel-list .channel-cell:selected .primary-text {
     -fx-background-color: -chat-accent-selected;
 }
@@ -70,8 +67,8 @@ leads it to covering the entire width **/
 }
 
 .channel-icon {
-    -fx-text-fill: -chat-text-fill;
-    -fx-background-color: -chat-background;
+    -fx-text-fill: -chat-text-sent-fill-500;
+    -fx-background-color: -chat-background-500;
     -fx-border-radius: 50;
     -fx-background-radius: 50;
     -fx-alignment: center;

--- a/App/src/main/resources/com/gluonhq/chat/views/chat.css
+++ b/App/src/main/resources/com/gluonhq/chat/views/chat.css
@@ -4,8 +4,8 @@
 
 .chat-channel-box {
     -fx-alignment: center;
-    -fx-background-color: -chat-background-light;
-    -fx-border-color: -chat-accent-light;
+    -fx-background-color: -chat-background-200;
+    -fx-border-color: -chat-accent-200;
     -fx-border-width: 0 0 2 0;
     -fx-spacing: 10;
     -fx-padding: 2 5 2 25;
@@ -27,8 +27,8 @@
 }
 
 .chat-channel-box > .chat-channel-icon > .chat-channel-icon {
-    -fx-text-fill: -chat-text-fill-light;
-    -fx-background-color: -chat-background;
+    -fx-text-fill: -chat-text-sent-fill-200;
+    -fx-background-color: -chat-background-500;
     -fx-border-radius: 40;
     -fx-background-radius: 40;
     -fx-alignment: center;
@@ -39,20 +39,20 @@
 }
 
 .chat-channel-box > .label.chat-channel-name {
-    -fx-text-fill: -chat-text-fill;
+    -fx-text-fill: -chat-text-sent-fill-500;
     -fx-font-size: 1.2em;
 }
 
 .chat-channel-box > .chat-channel-button {
     -fx-font-family: "FontAwesome";
     -fx-font-size: 1.5em;
-    -fx-text-fill: -chat-text-fill;
+    -fx-text-fill: -chat-text-sent-fill-500;
     -fx-background-color: transparent;
     -fx-effect: null;
 }
 
 .chat-toolbar {
-    -fx-background-color: -chat-accent;
+    -fx-background-color: -chat-accent-500;
     -fx-padding: 10;
     -fx-alignment: center-left;
     -fx-spacing: 10;
@@ -60,11 +60,11 @@
 }
 
 .chat-toolbar .label {
-    -fx-text-fill: -chat-text-fill-light;
+    -fx-text-fill: -chat-text-sent-fill-200;
 }
 
 .chat-bottom-bar {
-    -fx-background-color: -chat-background;
+    -fx-background-color: -chat-background-500;
     -fx-background-radius: 3em;
     /* Margin fix start */
     -fx-padding: 0.75em 1.25em 0.75em 1.25em;
@@ -83,8 +83,8 @@
 .chat-bottom-bar .chat-text-editor {
     -fx-background-color: transparent;
     -fx-font-size: 1em;
-    -fx-text-fill: -chat-text-fill;
-    -fx-prompt-text-fill: derive(-chat-text-fill, 50%);
+    -fx-text-fill: -chat-text-sent-fill-500;
+    -fx-prompt-text-fill: derive(-chat-text-sent-fill-500, 50%);
     -fx-wrap-text: true;
     -fx-border-width: 0;
 }
@@ -100,7 +100,7 @@
 }
 
 .chat-bottom-bar .chat-text-editor .paragraph-text .text {
-    -fx-fill: -chat-text-fill;
+    -fx-fill: -chat-text-sent-fill-500;
 }
 
 /** Emoji Button inside Text Editor **/
@@ -110,11 +110,11 @@
 }
 
 .chat-bottom-bar .chat-text-editor > .emoji-button > .icon {
-    -fx-background-color: -chat-text-fill;
+    -fx-background-color: -chat-text-sent-fill-500;
 }
 
 .chat-bottom-bar .chat-text-editor > .emoji-button:hover > .icon {
-    -fx-background-color: -chat-text-fill-dark;
+    -fx-background-color: -chat-text-sent-fill-700;
 }
 
 /** Text Area inside Text Editor **/
@@ -123,7 +123,7 @@
 }
 
 .chat-bottom-bar .chat-text-editor .styled-text-area .text {
-    -fx-text-fill: -chat-text-fill;
+    -fx-text-fill: -chat-text-sent-fill-500;
 }
 
 .chat-bottom-bar .chat-text-editor > .virtualized-scroll-pane {
@@ -135,13 +135,13 @@
 .chat-bottom-bar .chat-button {
     -fx-font-family: "FontAwesome";
     -fx-font-size: 1.5em;
-    -fx-text-fill: -chat-text-fill;
+    -fx-text-fill: -chat-text-sent-fill-500;
     -fx-background-color: transparent;
     -fx-effect: null;
 }
 
 .chat-bottom-bar .chat-button:hover {
-    -fx-text-fill: -chat-text-fill-dark;
+    -fx-text-fill: -chat-text-sent-fill-700;
     -fx-background-color: transparent;
 }
 
@@ -174,62 +174,41 @@
     -fx-padding: 10;
 }
 
-.chat-message-sent {
-    -fx-background-color: -chat-bubble-background;
-}
-
-.chat-message-received {
-    -fx-background-color: #e9e9e9;
-}
-
-.chat-message-text {
-    /*-fx-background-color: -chat-bubble-background;*/
+.chat-message > .chat-message-bubble {
+    -fx-background-color: -chat-bubble-received-background;
     -fx-padding: 5 10 5 10;
     -fx-background-radius: 0 .8em .8em .8em;
 }
 
-.chat-message-bubble:right .chat-message-text {
-    -fx-background-radius: .8em 0 .8em .8em;
+.chat-message > .chat-message-bubble > * > .text {
+    -fx-fill: -chat-text-received-fill-500;
 }
 
-.chat-message-text > .text {
-    -fx-fill: -chat-text-fill;
+.chat-message > .chat-message-bubble:sent {
+    -fx-background-color: -chat-bubble-sent-background;
 }
 
-.chat-message-bubble .chat-message-text-handle {
-    -fx-padding: 10 0 0 10;
-    -fx-alignment: top-right;
+.chat-message > .chat-message-bubble:sent > * > .text {
+    -fx-fill: -chat-text-sent-fill-500;
 }
 
-.chat-message-bubble:right .chat-message-text-handle {
-    -fx-padding: 10 10 0 0;
-}
-
-.chat-message-date {
+.chat-message > .chat-message-bubble > HBox > .chat-message-date {
     -fx-font-size: 0.8em;
-    -fx-text-fill: -chat-text-fill-light;
+    -fx-text-fill: -chat-text-received-fill-200;
 }
 
-.chat-message-status {
+.chat-message > .chat-message-bubble > HBox > .chat-message-date:sent {
+    -fx-text-fill: -chat-text-sent-fill-200;
+}
+
+.chat-message > .chat-message-bubble > HBox > .chat-message-status {
     -fx-font-family: "FontAwesome";
     -fx-font-size: 0.8em;
-    -fx-text-fill: -chat-text-fill-light;
+    -fx-text-fill: -chat-text-sent-fill-200;
 }
 
-.chat-message-status:read {
-    -fx-text-fill: -chat-text-fill-blue-light;
-}
-
-.user-icon {
-    -fx-text-fill: -chat-text-fill-light;
-    -fx-background-color: -chat-background;
-    -fx-border-width: 2.5;
-    -fx-border-radius: 35;
-    -fx-background-radius: 35;
-    -fx-alignment: top-right;
-    -fx-padding: 15;
-    -fx-font-size: 1.1em;
-    -fx-font-weight: bold;
+.chat-message > .chat-message-bubble > HBox > .chat-message-status:read {
+    -fx-text-fill: -chat-text-fill-blue-200;
 }
 
 .outer-box {

--- a/App/src/main/resources/styles.css
+++ b/App/src/main/resources/styles.css
@@ -20,57 +20,77 @@
     -fx-font-family: 'Inter'; /* uses all available weights*/
     -fx-font-size: 10pt;
 
-    /* accent color palette */
-    -chat-accent       : #4aadda;
-    -chat-accent-light : derive( -chat-accent, 100% );
-    -chat-accent-dark  : derive( -chat-accent, -20% );
+    /* default color palette for light theme
+    -500: default color
+    -200: lighter version
+    -700: darker version
+    */
+    -chat-background-500     : #EBEDEF;
+    -chat-background-200     : #ffffff; /* derive( -chat-background-500, 100% ); */
+    -chat-background-700     : #bcbebf; /* derive( -chat-background-500, -20% ); */
 
-    /* background color palette */
-    -chat-background       : #EBEDEF;
-    -chat-background-light : white;
-    -chat-background-dark  : derive( -chat-background, -20% );
+    /* accent color palette */
+    -chat-accent-500         : #4aadda;
+    -chat-accent-200         : #ebf6fb; /* derive( -chat-accent-500, 100% ); */
+    -chat-accent-700         : #3b8cae; /* derive( -chat-accent-500, -20% ); */
+
+    -chat-fill-500           : #e9e9e9;
 
     /* text color palette */
-    -chat-text-fill       : #5c5c5c;
-    -chat-text-fill-light : derive( -chat-text-fill,  50% );
-    -chat-text-fill-dark  : derive( -chat-text-fill, -20% );
-    -chat-text-fill-blue       : #235e95;
-    -chat-text-fill-blue-light  : derive( -chat-text-fill-blue,  50% );
-    -chat-text-fill-blue-dark   : derive( -chat-text-fill-blue,  -20% );
+    -chat-text-1-fill-500    : #5c5c5c;
+    -chat-text-1-fill-200    : #959595; /* derive( -chat-text-1-fill-500,  50% ); */
+    -chat-text-1-fill-700    : #4a4a4a; /* derive( -chat-text-1-fill-500, -20% ); */
+    -chat-text-2-fill-500    : #1b1b1b;
+    -chat-text-2-fill-200    : #5f5f5f; /* derive( -chat-text-2-fill-500,  50% ); */
+    -chat-text-2-fill-700    : #181818; /* derive( -chat-text-2-fill-500, -20% ); */
+
+    -chat-text-fill-blue-500 : #235e95;
+    -chat-text-fill-blue-200 : #5e8fba; /* derive( -chat-text-fill-blue-500,  50% ); */
+    -chat-text-fill-blue-700 : #1c4d77; /* derive( -chat-text-fill-blue-500, -20% ); */
+
+    -unread-label            : #f17835;
+    -unread-color            : #f17835cc;
+    -unread-color-hover      : #df502dcc;
+
+    /* text related vars */
+    -chat-text-sent-fill-500       : -chat-text-1-fill-500;
+    -chat-text-sent-fill-200       : -chat-text-1-fill-200;
+    -chat-text-sent-fill-700       : -chat-text-1-fill-700;
+
+    -chat-text-received-fill-500   : -chat-text-2-fill-500;
+    -chat-text-received-fill-200   : -chat-text-2-fill-200;
+    -chat-text-received-fill-700   : -chat-text-2-fill-700;
 
     /** Views related vars */
-    -chat-accent-selected: -chat-accent-light;
-    -chat-bubble-background: -chat-accent-light;
-
-    -unread-label: #f17835;
-    -unread-color: #f17835cc;
-    -unread-color-hover: #df502dcc;
+    -chat-accent-selected          : -chat-accent-200;
+    -chat-bubble-sent-background   : -chat-accent-200;
+    -chat-bubble-received-background : -chat-fill-500;
 
     /** Glisten swatch */
-    -primary-swatch-500: -chat-accent;
+    -primary-swatch-500: -chat-accent-500;
 }
 
 .view {
-    -fx-background-color: -chat-background-light;
+    -fx-background-color: -chat-background-200;
 }
 
 .app-bar {
-    -fx-background-color: -chat-background-light;
+    -fx-background-color: -chat-background-200;
 }
 
 .app-bar,
 .app-bar > .title-box > .label {
-    -fx-icon-fill: -chat-text-fill;
+    -fx-icon-fill: -chat-text-sent-fill-500;
 }
 
 .app-bar  > .action-items > .icon-toggle {
-    -fx-text-fill: -chat-text-fill;
+    -fx-text-fill: -chat-text-sent-fill-500;
     -fx-label-padding: 0 0 0 0;
 }
 
 .app-bar  > .action-items > .icon-toggle:hover {
-    -fx-text-fill: -chat-text-fill-dark;
-    -fx-background-color: -chat-background-dark;
+    -fx-text-fill: -chat-text-sent-fill-700;
+    -fx-background-color: -chat-background-700;
 }
 
 .font-icon {

--- a/App/src/main/resources/styles_dark.css
+++ b/App/src/main/resources/styles_dark.css
@@ -1,25 +1,25 @@
 @import "styles.css";
 
 .root {
-    /* accent color pallete */
-    -chat-accent       : #4aadda;
-    -chat-accent-light : derive( -chat-accent, 100% );
-    -chat-accent-dark  : derive( -chat-accent, -20% );
 
-    /* background color palette */
-    -chat-background       : #677585;
-    -chat-background-light : derive( -chat-background, -20% );
-    -chat-background-dark  : derive( -chat-background,  20% );
+    /* default color palette for dark theme
+    -500: default color
+    -200: darker version
+    -700: lighter version
+    */
 
-    /* text color palette */
-    -chat-text-fill       : #e7e4e4;
-    -chat-text-fill-light : derive( -chat-text-fill,  50% );
-    -chat-text-fill-dark  : derive( -chat-text-fill, -20% );
+    -chat-background-500     : #677585;
+    -chat-background-200     : #525e6a; /* derive( -chat-background-500, -20% ); */
+    -chat-background-700     : #7c8999; /* derive( -chat-background-500,  20% ); */
 
-    /** Views related vars */
-    -chat-accent-selected: -chat-background-dark;
-    -chat-bubble-background: -chat-background-dark;
+    -chat-accent-500         : #3b8cae;
+    -chat-accent-200         : #7c8999;
+    -chat-fill-500           : #474747;
 
-    /** Glisten swatch */
-    -primary-swatch-500: -chat-accent;
+    -chat-text-1-fill-500    : #e7e4e4;
+    -chat-text-1-fill-200    : #b9b6b6; /* derive( -chat-text-1-fill-500, -20% ); */
+    -chat-text-1-fill-700    : #efeded; /* derive( -chat-text-1-fill-500,  20% ); */
+    -chat-text-2-fill-500    : #e9e9e9;
+    -chat-text-2-fill-200    : #bababa; /* derive( -chat-text-2-fill-500, -20% ); */
+    -chat-text-2-fill-700    : #f0f0f0; /* derive( -chat-text-2-fill-500,  20% ); */
 }


### PR DESCRIPTION
Fixes #156
Follow-up of #127 

This PR tries to set a color palette for light (default) and dark themes, and a number of css variables that can be used with either set of colors.

While further changes to any of these colors should be easier, so far most of the colors remain the same as they are now (except some changes for the dark theme to fix #156).